### PR TITLE
Add runtime API proxy and use relative API path

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -13,16 +13,6 @@ const nextConfig = {
   experimental: {
     typedRoutes: true,
   },
-  async rewrites() {
-    // In production, API calls go through this rewrite so the web container
-    // can call the API container on the internal Docker network.
-    return [
-      {
-        source: "/api/v1/:path*",
-        destination: `${process.env.NEXT_PUBLIC_API_URL ?? "http://api:3001"}/v1/:path*`,
-      },
-    ]
-  },
 }
 
 export default nextConfig

--- a/apps/web/src/app/api/v1/[...path]/route.ts
+++ b/apps/web/src/app/api/v1/[...path]/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Runtime reverse-proxy for all /api/v1/* requests.
+ *
+ * The browser always calls relative URLs (/api/v1/...) so this works
+ * regardless of deployment URL. The Next.js server proxies requests to
+ * INTERNAL_API_URL (set via ConfigMap / docker-compose env) at runtime —
+ * no build-time knowledge of the API hostname is needed.
+ */
+
+import { type NextRequest, NextResponse } from "next/server"
+
+const INTERNAL_API_URL =
+  process.env.INTERNAL_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001"
+
+async function proxy(req: NextRequest, params: Promise<{ path: string[] }>) {
+  const { path } = await params
+  const upstream = `${INTERNAL_API_URL}/v1/${path.join("/")}${req.nextUrl.search}`
+
+  const headers = new Headers(req.headers)
+  // Strip Next.js internal / hop-by-hop headers before forwarding.
+  headers.delete("host")
+  headers.delete("connection")
+  headers.delete("transfer-encoding")
+
+  const body =
+    req.method === "GET" || req.method === "HEAD" ? undefined : req.body
+
+  let res: Response
+  try {
+    res = await fetch(upstream, {
+      method: req.method,
+      headers,
+      body,
+      // @ts-expect-error — Node 18+ fetch supports duplex
+      duplex: body ? "half" : undefined,
+    })
+  } catch (err) {
+    console.error("[api-proxy] upstream error:", err)
+    return NextResponse.json({ message: "API unreachable" }, { status: 502 })
+  }
+
+  const responseHeaders = new Headers(res.headers)
+  responseHeaders.delete("transfer-encoding")
+
+  return new NextResponse(res.body, {
+    status: res.status,
+    headers: responseHeaders,
+  })
+}
+
+export const GET = (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) =>
+  proxy(req, ctx.params)
+export const POST = (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) =>
+  proxy(req, ctx.params)
+export const PUT = (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) =>
+  proxy(req, ctx.params)
+export const PATCH = (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) =>
+  proxy(req, ctx.params)
+export const DELETE = (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) =>
+  proxy(req, ctx.params)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,7 +4,9 @@
  * are set in one place.
  */
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001"
+// Relative prefix — browser calls /api/v1/... which the Next.js route handler
+// proxies to INTERNAL_API_URL (vitasync-api:3001 in K8s, localhost:3001 in dev).
+const API_URL = "/api"
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const apiKey =


### PR DESCRIPTION
Remove the build-time /api/v1 rewrite from next.config and add a Next.js runtime reverse-proxy at apps/web/src/app/api/v1/[...path]/route.ts that forwards all /api/v1/* requests to INTERNAL_API_URL (env-configurable) at runtime. The proxy strips hop-by-hop headers, forwards request bodies (with duplex when needed), and returns upstream status/headers or a 502 JSON error if the API is unreachable. Update the frontend API client to use a relative "/api" prefix so browser requests go through the new proxy (no build-time knowledge of the API host required). Files changed: next.config.mjs (rewrites removed), new route.ts proxy, and lib/api.ts (API_URL -> "/api").