### PR TITLE
Seed admin key, tighten config, and add user guards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,17 +20,27 @@ NODE_ENV=development
 # ── Security ─────────────────────────────────────────────────
 # Generate with: openssl rand -hex 32
 JWT_SECRET=change-me-to-a-long-random-string-in-production
-ENCRYPTION_KEY=change-me-32-byte-hex-encoded-key
+# Must be exactly 64 hex characters (32 bytes). Generate with: openssl rand -hex 32
+ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
 
-# Initial admin workspace credentials (auto-created on first boot)
+# ── Bootstrap ──────────────────────────────────────────────
+# If set, creates a workspace + admin API key on first boot (idempotent).
+# Key must start with vs_live_ (production) or vs_test_ (non-production).
 ADMIN_WORKSPACE_SLUG=default
-ADMIN_API_KEY=vs_live_changeme_for_production
+ADMIN_API_KEY=vs_live_changeme_replace_with_a_real_random_key_value
 
 # ── CORS ─────────────────────────────────────────────────────
 CORS_ORIGINS=http://localhost:3000
 
-# ── Web Dashboard ────────────────────────────────────────────
+# ── Web / Proxy ──────────────────────────────────────────────
+# Used by the Next.js server to proxy /api/v1/* requests internally.
+# In Docker this must be the service name, not localhost.
+INTERNAL_API_URL=http://localhost:3001
+# Browser-facing API URL (used by client-side JS)
 NEXT_PUBLIC_API_URL=http://localhost:3001
+# Dev-only: pre-fills the dashboard API key without visiting Settings.
+# Leave blank (or unset) in production.
+NEXT_PUBLIC_DEFAULT_API_KEY=
 
 # ── Rate Limiting ────────────────────────────────────────────
 RATE_LIMIT_MAX=100

--- a/apps/api/src/__tests__/health-data.test.ts
+++ b/apps/api/src/__tests__/health-data.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { HealthDataService } from "../services/health-data.service.js"
-import { TEST_USER_ID, buildTestApp } from "./helpers.js"
+import { UserService } from "../services/user.service.js"
+import { TEST_USER_ID, TEST_WORKSPACE_ID, buildTestApp } from "./helpers.js"
+
+vi.mock("../services/user.service.js", () => {
+  const UserService = vi.fn()
+  UserService.prototype.findById = vi.fn()
+  return { UserService }
+})
 
 vi.mock("../services/health-data.service.js", () => {
   const HealthDataService = vi.fn()
@@ -23,11 +30,17 @@ const mockMetric = {
   createdAt: new Date("2025-06-01"),
 }
 
+const mockUser = {
+  id: TEST_USER_ID,
+  workspaceId: TEST_WORKSPACE_ID,
+}
+
 describe("Health data routes", () => {
   let app: Awaited<ReturnType<typeof buildTestApp>>
 
   beforeEach(async () => {
     vi.resetAllMocks()
+    vi.mocked(UserService.prototype.findById).mockResolvedValue(mockUser as never)
     app = await buildTestApp()
   })
 
@@ -36,7 +49,6 @@ describe("Health data routes", () => {
       vi.mocked(HealthDataService.prototype.query).mockResolvedValue({
         data: [mockMetric] as never,
         hasMore: false,
-        nextCursor: undefined,
       })
 
       const res = await app.inject({

--- a/apps/api/src/__tests__/helpers.ts
+++ b/apps/api/src/__tests__/helpers.ts
@@ -2,7 +2,7 @@
  * Test helpers — build a lightweight Fastify instance with mocked auth,
  * allowing route tests to run without a real DB connection.
  */
-import Fastify from "fastify"
+import Fastify, { type FastifyError } from "fastify"
 import { ZodError } from "zod"
 import { registerV1Routes } from "../routes/v1/index.js"
 
@@ -25,7 +25,7 @@ export async function buildTestApp(scopes: string[] = ["read", "write", "admin"]
   })
 
   // Convert Zod validation errors to 400 (mirrors production error handler)
-  app.setErrorHandler(async (error, _req, reply) => {
+  app.setErrorHandler<FastifyError>(async (error, _req, reply) => {
     if (error instanceof ZodError) {
       return reply.status(400).send({
         code: "VALIDATION_ERROR",

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -33,7 +33,9 @@ describe("Users routes", () => {
 
   describe("POST /v1/users", () => {
     it("creates a new user and returns 201", async () => {
-      vi.mocked(UserService.prototype.findOrCreate).mockResolvedValue(mockUser as never)
+      vi.mocked(UserService.prototype.findOrCreate).mockResolvedValue(
+        { user: mockUser, created: true } as never,
+      )
 
       const res = await app.inject({
         method: "POST",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -7,7 +7,7 @@ const EnvSchema = z.object({
   DATABASE_URL: z.string().url(),
   REDIS_URL: z.string().url(),
   JWT_SECRET: z.string().min(32, "JWT_SECRET must be at least 32 characters"),
-  ENCRYPTION_KEY: z.string().min(32, "ENCRYPTION_KEY must be at least 32 characters"),
+  ENCRYPTION_KEY: z.string().length(64, "ENCRYPTION_KEY must be 64 hex chars (32 bytes)"),
   CORS_ORIGINS: z
     .string()
     .default("http://localhost:3000")
@@ -16,6 +16,9 @@ const EnvSchema = z.object({
   RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
   LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
   OAUTH_REDIRECT_BASE_URL: z.string().url().default("http://localhost:3001"),
+  // Bootstrap: if set, a workspace + admin API key are created on first boot
+  ADMIN_WORKSPACE_SLUG: z.string().default("default"),
+  ADMIN_API_KEY: z.string().optional(),
 })
 
 const result = EnvSchema.safeParse(process.env)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,61 @@
-import { closeDb, initDb } from "@biosync-io/db"
+import { createHash } from "node:crypto"
+import { closeDb, getDb, initDb } from "@biosync-io/db"
+import { apiKeys, workspaces } from "@biosync-io/db"
 import { registerFitbitProvider } from "@biosync-io/provider-fitbit"
 import { registerGarminProvider } from "@biosync-io/provider-garmin"
 import { registerStravaProvider } from "@biosync-io/provider-strava"
 import { registerWhoopProvider } from "@biosync-io/provider-whoop"
+import { eq } from "drizzle-orm"
 import { config } from "./config.js"
 import { buildServer } from "./server.js"
+
+/**
+ * Seeds an initial workspace + admin API key on first boot.
+ *
+ * Runs only when ADMIN_API_KEY is set AND no workspaces exist yet.
+ * Idempotent: if the workspace slug already exists, it re-uses it.
+ */
+async function bootstrap(log: { info: (msg: string) => void }) {
+  if (!config.ADMIN_API_KEY) return
+
+  const db = getDb()
+  const rawKey = config.ADMIN_API_KEY
+
+  // Find or create the admin workspace
+  let [workspace] = await db
+    .select()
+    .from(workspaces)
+    .where(eq(workspaces.slug, config.ADMIN_WORKSPACE_SLUG))
+    .limit(1)
+
+  if (!workspace) {
+    ;[workspace] = await db
+      .insert(workspaces)
+      .values({ name: config.ADMIN_WORKSPACE_SLUG, slug: config.ADMIN_WORKSPACE_SLUG })
+      .onConflictDoNothing()
+      .returning()
+    log.info(`Bootstrap: created workspace '${config.ADMIN_WORKSPACE_SLUG}'`)
+  }
+
+  if (!workspace) return // conflict race (shouldn't happen in single-instance)
+
+  // Upsert the admin API key by its hash so this is fully idempotent
+  const keyHash = createHash("sha256").update(rawKey).digest("hex")
+  const keyPrefix = rawKey.slice(0, 12)
+
+  await db
+    .insert(apiKeys)
+    .values({
+      workspaceId: workspace.id,
+      name: "Admin Key",
+      keyHash,
+      keyPrefix,
+      scopes: ["read", "write", "admin"],
+    })
+    .onConflictDoNothing() // unique constraint on key_hash
+
+  log.info(`Bootstrap: admin API key ready (prefix: ${keyPrefix})`)
+}
 
 async function main() {
   // ── Register provider plugins ────────────────────────────────
@@ -15,6 +66,9 @@ async function main() {
 
   // ── Initialize database connection ───────────────────────────
   initDb(config.DATABASE_URL)
+
+  // ── Seed initial admin workspace + API key ───────────────────
+  await bootstrap({ info: (msg) => console.info(msg) })
 
   // ── Build and start Fastify ───────────────────────────────────
   const app = await buildServer()

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -22,9 +22,11 @@ declare module "fastify" {
  */
 const authPlugin: FastifyPluginAsync = async (app) => {
   app.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
-    // Skip auth for docs, health check, OAuth callbacks, and inbound provider webhooks
-    const skipPaths = ["/docs", "/health", "/v1/oauth", "/v1/inbound"]
+    // Skip auth for docs, health checks, and inbound provider webhooks
+    const skipPaths = ["/docs", "/health", "/v1/inbound"]
     if (skipPaths.some((p) => request.url.startsWith(p))) return
+    // OAuth callbacks are browser redirects from the provider — no API key in this flow
+    if (/^\/v1\/oauth\/[^/]+\/callback(\?|$)/.test(request.url)) return
 
     const authHeader = request.headers.authorization
     if (!authHeader?.startsWith("Bearer ")) {
@@ -57,7 +59,7 @@ const authPlugin: FastifyPluginAsync = async (app) => {
     // Attach workspace context to the request
     request.workspaceId = key.workspaceId
     request.apiKeyId = key.id
-    request.apiKeyScopes = key.scopes as string[]
+    request.apiKeyScopes = (key.scopes as string[]) ?? []
 
     // Fire-and-forget last-used update (non-blocking)
     db.update(apiKeys)

--- a/apps/api/src/queues/sync.ts
+++ b/apps/api/src/queues/sync.ts
@@ -1,14 +1,14 @@
 import { Queue } from "bullmq"
-import IORedis from "ioredis"
+import { Redis } from "ioredis"
 import { config } from "../config.js"
 
-let _connection: IORedis | null = null
+let _connection: Redis | null = null
 let _syncQueue: Queue | null = null
 let _webhookQueue: Queue | null = null
 
-function getConnection(): IORedis {
+function getConnection(): Redis {
   if (!_connection) {
-    _connection = new IORedis(config.REDIS_URL, {
+    _connection = new Redis(config.REDIS_URL, {
       maxRetriesPerRequest: null, // Required by BullMQ
       enableReadyCheck: false,
     })
@@ -22,7 +22,7 @@ function getConnection(): IORedis {
  */
 export function getSyncQueue(): Queue {
   if (!_syncQueue) {
-    _syncQueue = new Queue("sync", { connection: getConnection() })
+    _syncQueue = new Queue("sync", { connection: getConnection() as never })
   }
   return _syncQueue
 }
@@ -33,7 +33,7 @@ export function getSyncQueue(): Queue {
  */
 export function getWebhookQueue(): Queue {
   if (!_webhookQueue) {
-    _webhookQueue = new Queue("webhooks", { connection: getConnection() })
+    _webhookQueue = new Queue("webhooks", { connection: getConnection() as never })
   }
   return _webhookQueue
 }

--- a/apps/api/src/routes/v1/api-keys.ts
+++ b/apps/api/src/routes/v1/api-keys.ts
@@ -22,7 +22,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (app) => {
       workspaceId: request.workspaceId,
       name: body.name,
       scopes: body.scopes,
-      expiresAt: body.expiresAt ? new Date(body.expiresAt) : undefined,
+      ...(body.expiresAt !== undefined && { expiresAt: new Date(body.expiresAt) }),
     })
 
     // rawKey is only returned here — never stored, never shown again

--- a/apps/api/src/routes/v1/events.ts
+++ b/apps/api/src/routes/v1/events.ts
@@ -1,13 +1,17 @@
 import type { FastifyPluginAsync } from "fastify"
 import { z } from "zod"
 import { EventService } from "../../services/event.service.js"
+import { UserService } from "../../services/user.service.js"
 
 const eventService = new EventService()
+const userService = new UserService()
 
 const eventsRoutes: FastifyPluginAsync = async (app) => {
   // GET /v1/users/:userId/events — list events with cursor-based pagination
   app.get("/:userId/events", async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
 
     const query = z
       .object({
@@ -23,12 +27,12 @@ const eventsRoutes: FastifyPluginAsync = async (app) => {
     const result = await eventService.query({
       userId,
       workspaceId: request.workspaceId,
-      eventType: query.eventType,
-      activityType: query.activityType,
-      from: query.from ? new Date(query.from) : undefined,
-      to: query.to ? new Date(query.to) : undefined,
       limit: query.limit,
-      cursor: query.cursor,
+      ...(query.eventType !== undefined && { eventType: query.eventType }),
+      ...(query.activityType !== undefined && { activityType: query.activityType }),
+      ...(query.from !== undefined && { from: new Date(query.from) }),
+      ...(query.to !== undefined && { to: new Date(query.to) }),
+      ...(query.cursor !== undefined && { cursor: query.cursor }),
     })
 
     return reply.send(result)
@@ -39,6 +43,8 @@ const eventsRoutes: FastifyPluginAsync = async (app) => {
     const { userId, eventId } = z
       .object({ userId: z.string().uuid(), eventId: z.string().uuid() })
       .parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
 
     const event = await eventService.findById(eventId, userId)
     if (!event) {

--- a/apps/api/src/routes/v1/health-data.ts
+++ b/apps/api/src/routes/v1/health-data.ts
@@ -1,14 +1,19 @@
 import type { FastifyPluginAsync } from "fastify"
 import { z } from "zod"
+import { requireScope } from "../../plugins/auth.js"
 import { HealthDataService } from "../../services/health-data.service.js"
 import type { TimeseriesBucket } from "../../services/health-data.service.js"
+import { UserService } from "../../services/user.service.js"
 
 const healthDataService = new HealthDataService()
+const userService = new UserService()
 
 const healthDataRoutes: FastifyPluginAsync = async (app) => {
   // GET /v1/users/:userId/health — query health data with cursor-based pagination
   app.get("/:userId/health", async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
 
     const query = z
       .object({
@@ -24,12 +29,12 @@ const healthDataRoutes: FastifyPluginAsync = async (app) => {
     const result = await healthDataService.query({
       userId,
       workspaceId: request.workspaceId,
-      metricType: query.metricType as never,
-      from: query.from ? new Date(query.from) : undefined,
-      to: query.to ? new Date(query.to) : undefined,
       limit: query.limit,
       offset: query.cursor ? 0 : query.offset,
-      cursor: query.cursor,
+      ...(query.metricType !== undefined && { metricType: query.metricType as never }),
+      ...(query.from !== undefined && { from: new Date(query.from) }),
+      ...(query.to !== undefined && { to: new Date(query.to) }),
+      ...(query.cursor !== undefined && { cursor: query.cursor }),
     })
 
     return reply.send(result)
@@ -38,6 +43,8 @@ const healthDataRoutes: FastifyPluginAsync = async (app) => {
   // GET /v1/users/:userId/health/summary — counts per metric type
   app.get("/:userId/health/summary", async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
     const summary = await healthDataService.summary(userId)
     return reply.send(summary)
   })
@@ -45,6 +52,8 @@ const healthDataRoutes: FastifyPluginAsync = async (app) => {
   // GET /v1/users/:userId/health/timeseries — time-bucketed aggregation
   app.get("/:userId/health/timeseries", async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
 
     const query = z
       .object({
@@ -69,6 +78,8 @@ const healthDataRoutes: FastifyPluginAsync = async (app) => {
   // GET /v1/users/:userId/health/daily-summaries — per-day totals per metric
   app.get("/:userId/health/daily-summaries", async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
 
     const query = z
       .object({
@@ -83,17 +94,19 @@ const healthDataRoutes: FastifyPluginAsync = async (app) => {
 
     const summaries = await healthDataService.dailySummaries({
       userId,
-      metricTypes: query.metricTypes as never,
       from: new Date(query.from),
       to: new Date(query.to),
+      ...(query.metricTypes !== undefined && { metricTypes: query.metricTypes as never }),
     })
 
     return reply.send({ data: summaries })
   })
 
   // DELETE /v1/users/:userId/health — GDPR right-to-erasure
-  app.delete("/:userId/health", async (request, reply) => {
+  app.delete("/:userId/health", { preHandler: [requireScope("write")] }, async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
     const count = await healthDataService.deleteForUser(userId, request.workspaceId)
     return reply.send({ deleted: count })
   })

--- a/apps/api/src/routes/v1/inbound.ts
+++ b/apps/api/src/routes/v1/inbound.ts
@@ -58,7 +58,7 @@ const inboundRoutes: FastifyPluginAsync = async (app) => {
       const rawBody: Buffer =
         (request as typeof request & { rawBody?: Buffer }).rawBody ?? Buffer.from("")
 
-      if (provider.verifyWebhookSignature) {
+      if ("verifyWebhookSignature" in provider && provider.verifyWebhookSignature) {
         const valid = provider.verifyWebhookSignature(rawBody, signature, webhookSecret)
         if (!valid) {
           app.log.warn({ providerId }, "Inbound webhook signature verification failed")
@@ -85,7 +85,7 @@ const inboundRoutes: FastifyPluginAsync = async (app) => {
       }
 
       // ── Process data points ─────────────────────────────────
-      if (provider.processWebhook) {
+      if ("processWebhook" in provider && provider.processWebhook) {
         const dataPoints = await provider.processWebhook(request.body)
 
         if (dataPoints.length > 0) {

--- a/apps/api/src/routes/v1/oauth.ts
+++ b/apps/api/src/routes/v1/oauth.ts
@@ -47,7 +47,11 @@ const oauthRoutes: FastifyPluginAsync = async (app) => {
       state,
     )
 
-    stateStore.set(state, { userId, workspaceId: request.workspaceId, codeVerifier })
+    stateStore.set(state, {
+      userId,
+      workspaceId: request.workspaceId,
+      ...(codeVerifier !== undefined && { codeVerifier }),
+    })
 
     return reply.redirect(url, 302)
   })
@@ -95,7 +99,7 @@ const oauthRoutes: FastifyPluginAsync = async (app) => {
       providerId,
       code,
       redirectUri,
-      codeVerifier: stored.codeVerifier,
+      ...(stored.codeVerifier !== undefined && { codeVerifier: stored.codeVerifier }),
     })
 
     return reply.send({

--- a/apps/api/src/routes/v1/personal-records.ts
+++ b/apps/api/src/routes/v1/personal-records.ts
@@ -1,13 +1,17 @@
 import type { FastifyPluginAsync } from "fastify"
 import { z } from "zod"
 import { PersonalRecordService } from "../../services/personal-record.service.js"
+import { UserService } from "../../services/user.service.js"
 
 const personalRecordService = new PersonalRecordService()
+const userService = new UserService()
 
 const personalRecordsRoutes: FastifyPluginAsync = async (app) => {
   // GET /v1/users/:userId/personal-records — list all PRs for a user
   app.get("/:userId/personal-records", async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
     const records = await personalRecordService.list(userId)
     return reply.send({ data: records })
   })
@@ -17,6 +21,8 @@ const personalRecordsRoutes: FastifyPluginAsync = async (app) => {
     const { userId, metricType } = z
       .object({ userId: z.string().uuid(), metricType: z.string() })
       .parse(request.params)
+    const owner = await userService.findById(userId, request.workspaceId)
+    if (!owner) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
 
     const category = z.object({ category: z.string().optional() }).parse(request.query).category
 

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -8,7 +8,6 @@ const providersRoutes: FastifyPluginAsync = async (app) => {
       id: def.id,
       name: def.name,
       description: def.description,
-      authType: def.authType,
       capabilities: def.capabilities,
       logoUrl: def.logoUrl ?? null,
     }))
@@ -30,7 +29,6 @@ const providersRoutes: FastifyPluginAsync = async (app) => {
       id: def.id,
       name: def.name,
       description: def.description,
-      authType: def.authType,
       capabilities: def.capabilities,
       logoUrl: def.logoUrl ?? null,
     })

--- a/apps/api/src/routes/v1/users.ts
+++ b/apps/api/src/routes/v1/users.ts
@@ -22,11 +22,14 @@ const usersRoutes: FastifyPluginAsync = async (app) => {
   // POST /v1/users — create or find existing user
   app.post("/", { preHandler: [requireScope("write")] }, async (request, reply) => {
     const body = CreateUserBody.parse(request.body)
-    const user = await userService.findOrCreate({
+    const { user, created } = await userService.findOrCreate({
       workspaceId: request.workspaceId,
-      ...body,
+      externalId: body.externalId,
+      ...(body.email !== undefined && { email: body.email }),
+      ...(body.displayName !== undefined && { displayName: body.displayName }),
+      ...(body.metadata !== undefined && { metadata: body.metadata }),
     })
-    return reply.status(201).send(user)
+    return reply.status(created ? 201 : 200).send(user)
   })
 
   // GET /v1/users — list users in workspace
@@ -50,7 +53,11 @@ const usersRoutes: FastifyPluginAsync = async (app) => {
   app.patch("/:userId", { preHandler: [requireScope("write")] }, async (request, reply) => {
     const { userId } = z.object({ userId: z.string().uuid() }).parse(request.params)
     const body = UpdateUserBody.parse(request.body)
-    const user = await userService.update(userId, request.workspaceId, body)
+    const user = await userService.update(userId, request.workspaceId, {
+      ...(body.email !== undefined && { email: body.email }),
+      ...(body.displayName !== undefined && { displayName: body.displayName }),
+      ...(body.metadata !== undefined && { metadata: body.metadata }),
+    })
     if (!user) return reply.status(404).send({ code: "NOT_FOUND", message: "User not found" })
     return reply.send(user)
   })

--- a/apps/api/src/routes/v1/webhooks.ts
+++ b/apps/api/src/routes/v1/webhooks.ts
@@ -2,16 +2,17 @@ import type { FastifyPluginAsync } from "fastify"
 import { z } from "zod"
 import { requireScope } from "../../plugins/auth.js"
 import { WebhookService } from "../../services/webhook.service.js"
+import { WebhookEvent } from "@biosync-io/types"
 
 const webhookService = new WebhookService()
 
 const WebhookEventEnum = z.enum([
-  "sync.completed",
-  "sync.failed",
-  "connection.created",
-  "connection.disconnected",
-  "user.created",
-  "user.deleted",
+  WebhookEvent.SYNC_COMPLETED,
+  WebhookEvent.SYNC_FAILED,
+  WebhookEvent.CONNECTION_CREATED,
+  WebhookEvent.CONNECTION_DISCONNECTED,
+  WebhookEvent.USER_CREATED,
+  WebhookEvent.USER_DELETED,
 ])
 
 const webhooksRoutes: FastifyPluginAsync = async (app) => {
@@ -28,7 +29,10 @@ const webhooksRoutes: FastifyPluginAsync = async (app) => {
 
     const webhook = await webhookService.create({
       workspaceId: request.workspaceId,
-      ...body,
+      url: body.url,
+      secret: body.secret,
+      events: body.events as WebhookEvent[],
+      ...(body.description !== undefined && { description: body.description }),
     })
     return reply.status(201).send(webhook)
   })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,8 +3,9 @@ import helmet from "@fastify/helmet"
 import rateLimit from "@fastify/rate-limit"
 import swagger from "@fastify/swagger"
 import swaggerUi from "@fastify/swagger-ui"
-import Fastify from "fastify"
+import Fastify, { type FastifyError } from "fastify"
 import { config } from "./config.js"
+import authPlugin from "./plugins/auth.js"
 import { bullBoardPlugin } from "./plugins/bull-board.js"
 import { registerV1Routes } from "./routes/v1/index.js"
 
@@ -110,6 +111,7 @@ export async function buildServer() {
   })
 
   // ── Routes ───────────────────────────────────────────────────
+  await app.register(authPlugin)
   await app.register(registerV1Routes)
 
   // ── Bull Board queue dashboard ───────────────────────────────
@@ -143,7 +145,7 @@ export async function buildServer() {
   )
 
   // ── Global error handler ─────────────────────────────────────
-  app.setErrorHandler(async (error, _req, reply) => {
+  app.setErrorHandler<FastifyError>(async (error, _req, reply) => {
     // Log 5xx errors at error level, 4xx at warn
     if (error.statusCode && error.statusCode < 500) {
       app.log.warn({ err: error }, "Client error")

--- a/apps/api/src/services/connection.service.ts
+++ b/apps/api/src/services/connection.service.ts
@@ -16,18 +16,19 @@ export class ConnectionService {
 
   /**
    * Returns the OAuth2 authorization URL for the given provider.
-   * A PKCE code_verifier is included if the provider supports it.
+   * PKCE codeVerifier is not yet supported by the current provider implementations.
    */
   async getAuthorizationUrl(
     providerId: string,
-    redirectUri: string,
+    _redirectUri: string,
     state: string,
   ): Promise<{ url: string; codeVerifier?: string }> {
     const provider = providerRegistry.resolve(providerId)
     if (!("getAuthorizationUrl" in provider)) {
       throw new Error(`Provider '${providerId}' does not support OAuth2`)
     }
-    return provider.getAuthorizationUrl(redirectUri, state)
+    const url = provider.getAuthorizationUrl(state)
+    return { url: url.toString() }
   }
 
   /**
@@ -46,7 +47,7 @@ export class ConnectionService {
       throw new Error(`Provider '${params.providerId}' does not support OAuth2`)
     }
 
-    const tokens = await provider.exchangeCode(params.code, params.redirectUri, params.codeVerifier)
+    const tokens = await provider.exchangeCode(params.code)
     return this.upsertConnection(params.userId, params.workspaceId, params.providerId, tokens)
   }
 
@@ -62,18 +63,15 @@ export class ConnectionService {
       .insert(providerConnections)
       .values({
         userId,
-        workspaceId,
         providerId,
         encryptedTokens,
         status: "connected",
-        connectedAt: new Date(),
       })
       .onConflictDoUpdate({
         target: [providerConnections.userId, providerConnections.providerId],
         set: {
           encryptedTokens,
           status: "connected",
-          connectedAt: new Date(),
           updatedAt: new Date(),
         },
       })
@@ -90,46 +88,35 @@ export class ConnectionService {
       .limit(1)
 
     if (!conn) throw new Error(`Connection '${connectionId}' not found`)
+    if (!conn.encryptedTokens) throw new Error(`Connection '${connectionId}' has no stored tokens`)
 
     return JSON.parse(decrypt(conn.encryptedTokens, this.encryptionKey)) as ProviderTokens
   }
 
-  async list(userId: string, workspaceId: string): Promise<ProviderConnection[]> {
+  async list(userId: string, _workspaceId: string): Promise<ProviderConnection[]> {
     const rows = await this.db
       .select({
         id: providerConnections.id,
         userId: providerConnections.userId,
-        workspaceId: providerConnections.workspaceId,
         providerId: providerConnections.providerId,
         status: providerConnections.status,
         providerUserId: providerConnections.providerUserId,
         scopes: providerConnections.scopes,
-        connectedAt: providerConnections.connectedAt,
         lastSyncedAt: providerConnections.lastSyncedAt,
         createdAt: providerConnections.createdAt,
         updatedAt: providerConnections.updatedAt,
       })
       .from(providerConnections)
-      .where(
-        and(
-          eq(providerConnections.userId, userId),
-          eq(providerConnections.workspaceId, workspaceId),
-        ),
-      )
+      .where(eq(providerConnections.userId, userId))
 
     return rows as ProviderConnection[]
   }
 
-  async disconnect(connectionId: string, workspaceId: string): Promise<boolean> {
+  async disconnect(connectionId: string, _workspaceId: string): Promise<boolean> {
     const result = await this.db
       .update(providerConnections)
       .set({ status: "disconnected", updatedAt: new Date() })
-      .where(
-        and(
-          eq(providerConnections.id, connectionId),
-          eq(providerConnections.workspaceId, workspaceId),
-        ),
-      )
+      .where(eq(providerConnections.id, connectionId))
       .returning({ id: providerConnections.id })
 
     return result.length > 0

--- a/apps/api/src/services/event.service.ts
+++ b/apps/api/src/services/event.service.ts
@@ -55,7 +55,7 @@ export class EventService {
       nextCursor = encodeCursor(last.id, new Date(last.startedAt))
     }
 
-    return { data, nextCursor, hasMore }
+    return { data, hasMore, ...(nextCursor !== undefined && { nextCursor }) }
   }
 
   async findById(id: string, userId: string): Promise<EventRow | null> {

--- a/apps/api/src/services/health-data.service.ts
+++ b/apps/api/src/services/health-data.service.ts
@@ -32,6 +32,7 @@ export interface HealthDataQuery {
   to?: Date
   limit?: number
   offset?: number
+  cursor?: string
 }
 
 export interface HealthDataSummary {
@@ -83,7 +84,7 @@ export class HealthDataService {
       nextCursor = encodeCursor(last.id, new Date(last.recordedAt))
     }
 
-    return { data, nextCursor, hasMore }
+    return { data, hasMore, ...(nextCursor !== undefined && { nextCursor }) }
   }
 
   async summary(userId: string): Promise<HealthDataSummary[]> {
@@ -245,8 +246,8 @@ export class HealthDataService {
         metricType: dp.metricType,
         recordedAt: dp.recordedAt,
         value: dp.value ?? 0,
-        unit: dp.unit,
-        data: dp.data,
+        ...(dp.unit !== undefined && { unit: dp.unit }),
+        ...(dp.data !== undefined && { data: dp.data }),
       })),
     )
   }

--- a/apps/api/src/services/user.service.ts
+++ b/apps/api/src/services/user.service.ts
@@ -13,7 +13,7 @@ export class UserService {
     email?: string
     displayName?: string
     metadata?: Record<string, unknown>
-  }): Promise<User> {
+  }): Promise<{ user: User; created: boolean }> {
     const existing = await this.db
       .select()
       .from(users)
@@ -22,7 +22,7 @@ export class UserService {
       )
       .limit(1)
 
-    if (existing[0]) return existing[0] as User
+    if (existing[0]) return { user: existing[0] as User, created: false }
 
     const [created] = await this.db
       .insert(users)
@@ -35,7 +35,7 @@ export class UserService {
       })
       .returning()
 
-    return created as User
+    return { user: created as User, created: true }
   }
 
   async findById(id: string, workspaceId: string): Promise<User | null> {

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -57,7 +57,7 @@ export class WebhookService {
   ): Promise<Webhook | null> {
     const [updated] = await this.db
       .update(webhooks)
-      .set({ ...patch, updatedAt: new Date() })
+      .set(patch)
       .where(and(eq(webhooks.id, id), eq(webhooks.workspaceId, workspaceId)))
       .returning()
 

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
 import { type ApiKey, apiKeysApi } from "../../../lib/api"
 
 const STORAGE_KEY = "vitasync_api_key"
@@ -62,12 +63,8 @@ function ScopeTag({ scope }: { scope: string }) {
 }
 
 const ALL_SCOPES = [
-  { value: "read:users", label: "Read Users" },
-  { value: "write:users", label: "Write Users" },
-  { value: "read:health", label: "Read Health Data" },
-  { value: "read:events", label: "Read Events" },
-  { value: "read:providers", label: "Read Providers" },
-  { value: "write:connections", label: "Write Connections" },
+  { value: "read", label: "Read" },
+  { value: "write", label: "Write" },
   { value: "admin", label: "Admin (all)" },
 ]
 
@@ -102,11 +99,7 @@ export default function SettingsPage() {
   // Create key form
   const [createOpen, setCreateOpen] = useState(false)
   const [newKeyName, setNewKeyName] = useState("")
-  const [newKeyScopes, setNewKeyScopes] = useState<string[]>([
-    "read:users",
-    "read:health",
-    "read:events",
-  ])
+  const [newKeyScopes, setNewKeyScopes] = useState<string[]>(["read", "write"])
   const [newKeyExpiry, setNewKeyExpiry] = useState("")
   const [createdRawKey, setCreatedRawKey] = useState<string | null>(null)
 
@@ -120,7 +113,7 @@ export default function SettingsPage() {
     onSuccess: (data) => {
       setCreatedRawKey(data.rawKey)
       setNewKeyName("")
-      setNewKeyScopes(["read:users", "read:health", "read:events"])
+      setNewKeyScopes(["read", "write"])
       setNewKeyExpiry("")
       queryClient.invalidateQueries({ queryKey: ["api-keys"] })
     },
@@ -142,6 +135,9 @@ export default function SettingsPage() {
     return new Date(key.expiresAt) < new Date()
   }
 
+  const searchParams = useSearchParams()
+  const needsSetup = searchParams.get("setup") === "1" && !activeKey
+
   return (
     <div className="max-w-3xl space-y-8">
       <div>
@@ -151,7 +147,15 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      {/* ── Active API key ───────────────────────────────────────────────────── */}
+      {/* ── Setup banner ─────────────────────────────────────────────────────── */}
+      {needsSetup && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <strong>API key required.</strong> Paste your key below and click <strong>Save</strong> to
+          start using the dashboard. Use the <strong>Bootstrap key</strong>{" "}
+          (<code className="rounded bg-amber-100 px-1 font-mono">vs_test_dev0…</code>) for local
+          development, or create a new one below.
+        </div>
+      )}
       <section className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-100">
           <h2 className="text-sm font-semibold text-gray-900">Active API Key</h2>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,7 +10,16 @@ const API_URL = "/api"
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const apiKey =
-    typeof window !== "undefined" ? (localStorage.getItem("vitasync_api_key") ?? "") : ""
+    (typeof window !== "undefined" ? localStorage.getItem("vitasync_api_key") : null) ??
+    process.env.NEXT_PUBLIC_DEFAULT_API_KEY ??
+    ""
+
+  if (!apiKey) {
+    if (typeof window !== "undefined") {
+      window.location.href = "/dashboard/settings?setup=1"
+    }
+    throw new Error("No API key configured. Redirecting to Settings…")
+  }
 
   const res = await fetch(`${API_URL}${path}`, {
     ...init,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,6 +29,9 @@ services:
       ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
       CORS_ORIGINS: "http://localhost:3000"
       OAUTH_REDIRECT_BASE_URL: "http://localhost:3001"
+      # Bootstrap: creates the default workspace + admin key on first boot
+      ADMIN_WORKSPACE_SLUG: default
+      ADMIN_API_KEY: "vs_test_dev0000000000000000000000000000"
     volumes:
       - ./apps/api/src:/repo/apps/api/src:ro
     ports:
@@ -54,7 +57,12 @@ services:
     command: ["pnpm", "--filter", "@biosync-io/web", "dev"]
     environment:
       NODE_ENV: development
+      # Server-side proxy target — must use the Docker service name, not localhost
+      INTERNAL_API_URL: http://api:3001
+      # Browser-facing API URL (used by client-side code)
       NEXT_PUBLIC_API_URL: http://localhost:3001
+      # Pre-configured API key for local dev — avoids manual Settings setup
+      NEXT_PUBLIC_DEFAULT_API_KEY: "vs_test_dev0000000000000000000000000000"
     volumes:
       - ./apps/web/src:/repo/apps/web/src:ro
       - ./apps/web/public:/repo/apps/web/public:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,10 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://api:3001}
+      # Server-side proxy target — internal service name, never changes
+      INTERNAL_API_URL: http://api:3001
+      # Browser-facing API URL — set to your public domain in production
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
     ports:
       - "3000:3000"
     depends_on:

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -52,10 +52,12 @@ export interface Webhook {
 }
 
 export const WebhookEvent = {
-  DATA_SYNCED: "data.synced",
-  CONNECTION_CREATED: "connection.created",
-  CONNECTION_REVOKED: "connection.revoked",
+  SYNC_COMPLETED: "sync.completed",
   SYNC_FAILED: "sync.failed",
+  CONNECTION_CREATED: "connection.created",
+  CONNECTION_DISCONNECTED: "connection.disconnected",
+  USER_CREATED: "user.created",
+  USER_DELETED: "user.deleted",
 } as const
 export type WebhookEvent = (typeof WebhookEvent)[keyof typeof WebhookEvent]
 


### PR DESCRIPTION
Introduce bootstrap support and stricter validations plus several API and route hardening changes.

Key changes:
- Bootstrap: seed initial workspace and admin API key when ADMIN_API_KEY is set (apps/api/src/index.ts). Logs key prefix and is idempotent.
- Config/Env: ENCRYPTION_KEY now must be exactly 64 hex chars; .env.example updated with INTERNAL_API_URL, NEXT_PUBLIC_DEFAULT_API_KEY, and bootstrap notes.
- Docker: dev and prod docker-compose updated to provide bootstrap env and internal proxy URL; dev pre-sets a test admin key and NEXT_PUBLIC_DEFAULT_API_KEY.
- Routes: Add owner existence checks across many v1 routes (events, health-data, personal-records, users, api-keys, webhooks), use conditional property spreads to avoid passing undefined values, and require write scope for GDPR deletion of health data.
- Services: UserService.findOrCreate now returns { user, created } and callers updated; ConnectionService simplified OAuth flows (no PKCE support, fewer workspace constraints), removed some workspace constraints from connection queries/updates; HealthData/Event services avoid returning undefined fields; WebhookService.update no longer force-sets updatedAt here.
- Auth/plugin: refined skip rules (allow OAuth callback redirects) and ensure apiKeyScopes defaults to [] when missing; auth plugin registered in server.
- Queues: type ioredis connection as Redis and cast to satisfy BullMQ usage.
- Web UI: client-side API helper redirects to Settings when no API key, adds a setup banner, uses simplified scopes (read/write/admin) and supports NEXT_PUBLIC_DEFAULT_API_KEY.
- Types: WebhookEvent enum values updated to canonical event strings and used in webhooks route.
- Tests: updated mocks and tests to reflect UserService API and added user existence mocking.

Breaking changes / notes:
- ENCRYPTION_KEY length requirement changed (must be 64 hex chars). Update env in production.
- UserService.findOrCreate signature changed; adjust any external callers.
- New ADMIN_API_KEY/ADMIN_WORKSPACE_SLUG envs enable bootstrap behavior; keep blank in production if not desired.
- Webhook event constants changed; consumers should use the updated values.

Most changes are defensive and idempotency improvements to bootstrap, validation, and route behavior.